### PR TITLE
merge identical code for STM axis-based devices

### DIFF
--- a/l3g4200d.cpp
+++ b/l3g4200d.cpp
@@ -1,18 +1,7 @@
-#include <Arduino.h>
 #include <Wire.h>
 #include "l3g4200d.h"
 
 #define DEG_TO_RAD      0.0175
-
-#define CTRL_REG1       0x20
-#define CTRL_REG2       0x21
-#define CTRL_REG3       0x22
-#define CTRL_REG4       0x23
-#define CTRL_REG5       0x24
-
-#define OUT_X           0x28
-#define OUT_Y           0x2A
-#define OUT_Z           0x2C
 
 #define ADR_FS_250      0x00
 #define ADR_FS_500      0x10
@@ -22,8 +11,7 @@
 #define SENS_FS_500     0.0175
 #define SENS_FS_2000    0.07
 
-L3G4200D_TWI::L3G4200D_TWI(uint8_t addr) {
-    _addr = addr;
+L3G4200D_TWI::L3G4200D_TWI(uint8_t addr) : AxisHw(addr) {
 }
 
 void L3G4200D_TWI::setRange(uint8_t range) {
@@ -75,18 +63,6 @@ void L3G4200D_TWI::sleep(bool enable) {
     writeCtrlReg1();
 }
 
-int16_t L3G4200D_TWI::readX() {
-    return readAxis(OUT_X);
-}
-
-int16_t L3G4200D_TWI::readY() {
-    return readAxis(OUT_Y);
-}
-
-int16_t L3G4200D_TWI::readZ() {
-    return readAxis(OUT_Z);
-}
-
 float L3G4200D_TWI::readDegPerSecX() {
     return readX() * _mult;
 }
@@ -111,22 +87,6 @@ float L3G4200D_TWI::readRadPerSecZ() {
     return readZ() * _mult * DEG_TO_RAD;
 }
 
-void L3G4200D_TWI::readXYZ(int16_t *x, int16_t *y, int16_t *z) {
-    Wire.beginTransmission(_addr);
-    Wire.write(OUT_X | (1 << 7));  // assert MSB to enable register address auto-increment
-    Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)6);
-    uint8_t values[6];
-    for (uint8_t i = 0; i < 6; i++) {
-        values[i] = Wire.read();
-    }
-    Wire.endTransmission();
-    
-    *x = (((int16_t)values[1] << 8) | values[0]);
-    *y = (((int16_t)values[3] << 8) | values[2]);
-    *z = (((int16_t)values[5] << 8) | values[4]);
-}
-
 void L3G4200D_TWI::readDegPerSecXYZ(float *gx, float *gy, float *gz) {
     int16_t x, y, z;
     readXYZ(&x, &y, &z);
@@ -141,56 +101,4 @@ void L3G4200D_TWI::readRadPerSecXYZ(float *gx, float *gy, float *gz) {
     *gx = (float)x * _mult * DEG_TO_RAD;
     *gy = (float)y * _mult * DEG_TO_RAD;
     *gz = (float)z * _mult * DEG_TO_RAD;
-}
-
-int16_t L3G4200D_TWI::readAxis(uint8_t reg) {
-    return (((int16_t)readByte(reg + 1) << 8) | readByte(reg));
-}
-
-uint8_t L3G4200D_TWI::readByte(uint8_t reg) {
-    uint8_t value = 0;
-    Wire.beginTransmission(_addr);
-    Wire.write(reg);
-    Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)1);
-    while (Wire.available() < 1)
-        ;
-    value = Wire.read();
-    Wire.endTransmission();
-    return value;
-}
-
-void L3G4200D_TWI::writeCtrlReg1() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG1);
-    Wire.write(_ctrlReg1);
-    Wire.endTransmission();
-}
-
-void L3G4200D_TWI::writeCtrlReg2() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG2);
-    Wire.write(_ctrlReg2);
-    Wire.endTransmission();
-}
-
-void L3G4200D_TWI::writeCtrlReg3() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG3);
-    Wire.write(_ctrlReg3);
-    Wire.endTransmission();
-}
-
-void L3G4200D_TWI::writeCtrlReg4() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG4);
-    Wire.write(_ctrlReg4);
-    Wire.endTransmission();
-}
-
-void L3G4200D_TWI::writeCtrlReg5() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG5);
-    Wire.write(_ctrlReg5);
-    Wire.endTransmission();
 }

--- a/l3g4200d.h
+++ b/l3g4200d.h
@@ -1,48 +1,28 @@
 #ifndef L3G4200D_H
 #define L3G4200D_H
 
-#define L3G4200D_TWI_ADDRESS 0b01101000
+#include "stmhw.h"
 
+#define L3G4200D_TWI_ADDRESS 0b01101000
 #define RANGE_250DPS         0
 #define RANGE_500DPS         1
 #define RANGE_2000DPS        2
 
-
-class L3G4200D_TWI
+class L3G4200D_TWI : public AxisHw
 {
 public:
     L3G4200D_TWI(uint8_t addr = L3G4200D_TWI_ADDRESS);
     void begin();
     void sleep(bool enable);
     void setRange(uint8_t range);
-    uint8_t readByte(uint8_t reg);
-    int16_t readX();
-    int16_t readY();
-    int16_t readZ();
     float readDegPerSecX();
     float readDegPerSecY();
     float readDegPerSecZ();
     float readRadPerSecX();
     float readRadPerSecY();
     float readRadPerSecZ();
-    void readXYZ(int16_t *x, int16_t *y, int16_t *z);
     void readDegPerSecXYZ(float *gx, float *gy, float *gz);
     void readRadPerSecXYZ(float *gx, float *gy, float *gz);
-
-private:
-    uint8_t _addr;
-    float _mult;
-    uint8_t _ctrlReg1;
-    uint8_t _ctrlReg2;
-    uint8_t _ctrlReg3;
-    uint8_t _ctrlReg4;
-    uint8_t _ctrlReg5;
-    void writeCtrlReg1();
-    void writeCtrlReg2();
-    void writeCtrlReg3();
-    void writeCtrlReg4();
-    void writeCtrlReg5();
-    int16_t readAxis(uint8_t reg);
 };
 
 #endif

--- a/lis331dlh.cpp
+++ b/lis331dlh.cpp
@@ -1,16 +1,5 @@
-#include <Arduino.h>
 #include <Wire.h>
 #include "lis331dlh.h"
-
-#define CTRL_REG1       0x20
-#define CTRL_REG2       0x21
-#define CTRL_REG3       0x22
-#define CTRL_REG4       0x23
-#define CTRL_REG5       0x24
-
-#define OUT_X           0x28
-#define OUT_Y           0x2A
-#define OUT_Z           0x2C
 
 #define ADR_FS_2        0x00
 #define ADR_FS_4        0x10
@@ -18,8 +7,7 @@
 
 #define G               9.8
 
-LIS331DLH_TWI::LIS331DLH_TWI(uint8_t addr) {
-    _addr = addr;
+LIS331DLH_TWI::LIS331DLH_TWI(uint8_t addr) : AxisHw(addr) {
 }
 
 void LIS331DLH_TWI::begin() {
@@ -70,18 +58,6 @@ void LIS331DLH_TWI::sleep(bool enable) {
     writeCtrlReg1();
 }
 
-int16_t LIS331DLH_TWI::readX() {
-    return readAxis(OUT_X);
-}
-
-int16_t LIS331DLH_TWI::readY() {
-    return readAxis(OUT_Y);
-}
-
-int16_t LIS331DLH_TWI::readZ() {
-    return readAxis(OUT_Z);
-}
-
 float LIS331DLH_TWI::readGX() {
     return readX()*_mult;
 }
@@ -106,22 +82,6 @@ float LIS331DLH_TWI::readAZ() {
     return readZ() * _mult * G;
 }
 
-void LIS331DLH_TWI::readXYZ(int16_t *x, int16_t *y, int16_t *z) {
-    Wire.beginTransmission(_addr);
-    Wire.write(OUT_X | (1 << 7));  // assert MSB to enable register address auto-increment
-    Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)6);
-    uint8_t values[6];
-    for (uint8_t i = 0; i < 6; i++) {
-        values[i] = Wire.read();
-    }
-    Wire.endTransmission();
-    
-    *x = (((int16_t)values[1] << 8) | values[0]);
-    *y = (((int16_t)values[3] << 8) | values[2]);
-    *z = (((int16_t)values[5] << 8) | values[4]);
-}
-
 void LIS331DLH_TWI::readGXYZ(float *gx, float *gy, float *gz) {
     int16_t x, y, z;
     readXYZ(&x, &y, &z);
@@ -136,56 +96,4 @@ void LIS331DLH_TWI::readAXYZ(float *ax, float *ay, float *az) {
     *ax = (float)x * _mult * G;
     *ay = (float)y * _mult * G;
     *az = (float)z * _mult * G;
-}
-
-int16_t LIS331DLH_TWI::readAxis(uint8_t reg) {
-    return (((int16_t)readByte(reg + 1) << 8) | readByte(reg)) ;
-}
-
-uint8_t LIS331DLH_TWI::readByte(uint8_t reg) {
-    uint8_t value = 0;
-    Wire.beginTransmission(_addr);
-    Wire.write(reg);
-    Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)1);
-    while (Wire.available() < 1)
-        ;
-    value = Wire.read();
-    Wire.endTransmission();
-    return value;
-}
-
-void LIS331DLH_TWI::writeCtrlReg1() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG1);
-    Wire.write(_ctrlReg1);
-    Wire.endTransmission();
-}
-
-void LIS331DLH_TWI::writeCtrlReg2() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG2);
-    Wire.write(_ctrlReg2);
-    Wire.endTransmission();
-}
-
-void LIS331DLH_TWI::writeCtrlReg3() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG3);
-    Wire.write(_ctrlReg3);
-    Wire.endTransmission();
-}
-
-void LIS331DLH_TWI::writeCtrlReg4() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG4);
-    Wire.write(_ctrlReg4);
-    Wire.endTransmission();
-}
-
-void LIS331DLH_TWI::writeCtrlReg5() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG5);
-    Wire.write(_ctrlReg5);
-    Wire.endTransmission();
 }

--- a/lis331dlh.h
+++ b/lis331dlh.h
@@ -1,6 +1,7 @@
-
 #ifndef LIS331DLH_H
 #define LIS331DLH_H
+
+#include "stmhw.h"
 
 #define LIS331DLH_TWI_ADDRESS 0b0011000
 
@@ -8,41 +9,21 @@
 #define RANGE_4G        4
 #define RANGE_8G        8
 
-class LIS331DLH_TWI
+class LIS331DLH_TWI : public AxisHw
 {
 public:
     LIS331DLH_TWI(uint8_t addr = LIS331DLH_TWI_ADDRESS);
     void begin();
     void sleep(bool enable);
     void setRange(uint8_t range);
-    uint8_t readByte(uint8_t reg);
-    int16_t readX();
-    int16_t readY();
-    int16_t readZ();
     float readGX();
     float readGY();
     float readGZ();
     float readAX();
     float readAY();
     float readAZ();
-    void readXYZ(int16_t *x, int16_t *y, int16_t *z);
     void readGXYZ(float *ax, float *ay, float *az);
     void readAXYZ(float *gx, float *gy, float *gz);
-
-private:
-    uint8_t _addr;
-    float _mult;
-    uint8_t _ctrlReg1;
-    uint8_t _ctrlReg2;
-    uint8_t _ctrlReg3;
-    uint8_t _ctrlReg4;
-    uint8_t _ctrlReg5;
-    void writeCtrlReg1();
-    void writeCtrlReg2();
-    void writeCtrlReg3();
-    void writeCtrlReg4();
-    void writeCtrlReg5();
-    int16_t readAxis(uint8_t reg);
 };
 
 #endif

--- a/lis3mdl.cpp
+++ b/lis3mdl.cpp
@@ -1,16 +1,6 @@
-#include <Arduino.h>
 #include <Wire.h>
+#include <math.h>
 #include "lis3mdl.h"
-
-#define CTRL_REG1       0x20
-#define CTRL_REG2       0x21
-#define CTRL_REG3       0x22
-#define CTRL_REG4       0x23
-#define CTRL_REG5       0x24
-
-#define OUT_X           0x28
-#define OUT_Y           0x2A
-#define OUT_Z           0x2C
 
 #define ADR_FS_4        0x00
 #define ADR_FS_8        0x20
@@ -22,8 +12,7 @@
 #define SENS_FS_12      2281
 #define SENS_FS_16      1711
 
-LIS3MDL_TWI::LIS3MDL_TWI(uint8_t addr) {
-    _addr = addr;
+LIS3MDL_TWI::LIS3MDL_TWI(uint8_t addr) : AxisHw(addr) {
 }
 
 void LIS3MDL_TWI::begin() {
@@ -61,18 +50,6 @@ void LIS3MDL_TWI::setRange(uint8_t range) {
         break;
     }
     writeCtrlReg2();
-}
-
-int16_t LIS3MDL_TWI::readX() {
-    return readAxis(OUT_X);
-}
-
-int16_t LIS3MDL_TWI::readY() {
-    return readAxis(OUT_Y);
-}
-
-int16_t LIS3MDL_TWI::readZ() {
-    return readAxis(OUT_Z);
 }
 
 float LIS3MDL_TWI::readGaussX() {
@@ -154,64 +131,12 @@ float LIS3MDL_TWI::readAzimut() {
     float heading = atan2(_yCalibrate, _xCalibrate);
 
     if(heading < 0)
-    heading += 2 * PI;
+    heading += 2 * M_PI;
 
-    if(heading > 2 * PI)
-    heading -= 2 * PI;
+    if(heading > 2 * M_PI)
+    heading -= 2 * M_PI;
 
     float headingDegrees = heading * 180 / M_PI;
 
     return headingDegrees;
-}
-
-int16_t LIS3MDL_TWI::readAxis(uint8_t reg) {
-    return (((int16_t)readByte(reg + 1) << 8) | readByte(reg)) ;
-}
-
-uint8_t LIS3MDL_TWI::readByte(uint8_t reg) {
-    uint8_t value = 0;
-    Wire.beginTransmission(_addr);
-    Wire.write(reg);
-    Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)1);
-    while (Wire.available() < 1)
-        ;
-    value = Wire.read();
-    Wire.endTransmission();
-    return value;
-}
-
-void LIS3MDL_TWI::writeCtrlReg1() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG1);
-    Wire.write(_ctrlReg1);
-    Wire.endTransmission();
-}
-
-void LIS3MDL_TWI::writeCtrlReg2() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG2);
-    Wire.write(_ctrlReg2);
-    Wire.endTransmission();
-}
-
-void LIS3MDL_TWI::writeCtrlReg3() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG3);
-    Wire.write(_ctrlReg3);
-    Wire.endTransmission();
-}
-
-void LIS3MDL_TWI::writeCtrlReg4() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG4);
-    Wire.write(_ctrlReg4);
-    Wire.endTransmission();
-}
-
-void LIS3MDL_TWI::writeCtrlReg5() {
-    Wire.beginTransmission(_addr);
-    Wire.write(CTRL_REG5);
-    Wire.write(_ctrlReg5);
-    Wire.endTransmission();
 }

--- a/lis3mdl.h
+++ b/lis3mdl.h
@@ -1,6 +1,8 @@
 #ifndef LIS3MDL_H
 #define LIS3MDL_H
 
+#include "stmhw.h"
+
 #define LIS3MDL_TWI_ADDRESS 0b0011100
 
 #define RANGE_4_GAUSS   0
@@ -8,19 +10,14 @@
 #define RANGE_12_GAUSS  2
 #define RANGE_16_GAUSS  3
 
-class LIS3MDL_TWI
+class LIS3MDL_TWI : public AxisHw
 {
 public:
     LIS3MDL_TWI(uint8_t addr = LIS3MDL_TWI_ADDRESS);
-
     void begin();
     void setRange(uint8_t range);
     void calibrateMatrix(const double calibrationMatrix[3][3], const double bias[3]);
     void calibrate();
-    uint8_t readByte(uint8_t reg);
-    int16_t readX();
-    int16_t readY();
-    int16_t readZ();
     float readGaussX();
     float readGaussY();
     float readGaussZ();
@@ -34,24 +31,11 @@ public:
     void readCalibrateGaussXYZ(float *x, float *y, float *z);
 
 private:
-    uint8_t _addr;
-    float _mult;
     float _xCalibrate;
     float _yCalibrate;
     float _zCalibrate;
-    uint8_t _ctrlReg1;
-    uint8_t _ctrlReg2;
-    uint8_t _ctrlReg3;
-    uint8_t _ctrlReg4;
-    uint8_t _ctrlReg5;
     double _calibrationMatrix[3][3];
     double _bias[3];
-    void writeCtrlReg1();
-    void writeCtrlReg2();
-    void writeCtrlReg3();
-    void writeCtrlReg4();
-    void writeCtrlReg5();
-    int16_t readAxis(uint8_t reg);
 };
 
 #endif

--- a/stmhw.cpp
+++ b/stmhw.cpp
@@ -27,16 +27,19 @@ int16_t AxisHw::readAxis(uint8_t reg) {
     return ((int16_t)readByte(reg + 1) << 8) | readByte(reg);
 }
 
+inline void AxisHw::waitForData() {
+    while (Wire.available() < 1)
+        continue;
+}
+
 uint8_t AxisHw::readByte(uint8_t reg) {
-    uint8_t value = 0;
+    uint8_t value;
     Wire.beginTransmission(_addr);
     Wire.write(reg);
     Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)1);
-    while (Wire.available() < 1)
-        ;
+    Wire.requestFrom(_addr, 1u);
+    waitForData();
     value = Wire.read();
-    Wire.endTransmission();
     return value;
 }
 
@@ -44,16 +47,18 @@ void AxisHw::readXYZ(int16_t *x, int16_t *y, int16_t *z) {
     Wire.beginTransmission(_addr);
     Wire.write(OUT_X | (1 << 7));  // assert MSB to enable register address auto-increment
     Wire.endTransmission();
-    Wire.requestFrom(_addr, (uint8_t)6);
-    uint8_t values[6];
-    for (uint8_t i = 0; i < 6; i++) {
+
+    constexpr uint8_t burstSize = 6;
+    Wire.requestFrom(_addr, burstSize);
+    uint8_t values[burstSize];
+    for (uint8_t i = 0; i < burstSize; i++) {
+        waitForData();
         values[i] = Wire.read();
     }
-    Wire.endTransmission();
     
-    *x = (((int16_t)values[1] << 8) | values[0]);
-    *y = (((int16_t)values[3] << 8) | values[2]);
-    *z = (((int16_t)values[5] << 8) | values[4]);
+    *x = *((int16_t*)&values[0]);
+    *y = *((int16_t*)&values[2]);
+    *z = *((int16_t*)&values[4]);
 }
 
 void AxisHw::writeCtrlReg1(){

--- a/stmhw.cpp
+++ b/stmhw.cpp
@@ -1,0 +1,92 @@
+#include "stmhw.h"
+#include <Wire.h>
+
+#define CTRL_REG1       0x20
+#define CTRL_REG2       0x21
+#define CTRL_REG3       0x22
+#define CTRL_REG4       0x23
+#define CTRL_REG5       0x24
+
+#define OUT_X           0x28
+#define OUT_Y           0x2A
+#define OUT_Z           0x2C
+
+int16_t AxisHw::readX() {
+    return readAxis(OUT_X);
+}
+
+int16_t AxisHw::readY() {
+    return readAxis(OUT_Y);
+}
+
+int16_t AxisHw::readZ() {
+    return readAxis(OUT_Z);
+}
+
+int16_t AxisHw::readAxis(uint8_t reg) {
+    return ((int16_t)readByte(reg + 1) << 8) | readByte(reg);
+}
+
+uint8_t AxisHw::readByte(uint8_t reg) {
+    uint8_t value = 0;
+    Wire.beginTransmission(_addr);
+    Wire.write(reg);
+    Wire.endTransmission();
+    Wire.requestFrom(_addr, (uint8_t)1);
+    while (Wire.available() < 1)
+        ;
+    value = Wire.read();
+    Wire.endTransmission();
+    return value;
+}
+
+void AxisHw::readXYZ(int16_t *x, int16_t *y, int16_t *z) {
+    Wire.beginTransmission(_addr);
+    Wire.write(OUT_X | (1 << 7));  // assert MSB to enable register address auto-increment
+    Wire.endTransmission();
+    Wire.requestFrom(_addr, (uint8_t)6);
+    uint8_t values[6];
+    for (uint8_t i = 0; i < 6; i++) {
+        values[i] = Wire.read();
+    }
+    Wire.endTransmission();
+    
+    *x = (((int16_t)values[1] << 8) | values[0]);
+    *y = (((int16_t)values[3] << 8) | values[2]);
+    *z = (((int16_t)values[5] << 8) | values[4]);
+}
+
+void AxisHw::writeCtrlReg1(){
+    Wire.beginTransmission(_addr);
+    Wire.write(CTRL_REG1);
+    Wire.write(_ctrlReg1);
+    Wire.endTransmission();
+}
+
+void AxisHw::writeCtrlReg2(){
+    Wire.beginTransmission(_addr);
+    Wire.write(CTRL_REG2);
+    Wire.write(_ctrlReg2);
+    Wire.endTransmission();
+}
+
+void AxisHw::writeCtrlReg3(){
+    Wire.beginTransmission(_addr);
+    Wire.write(CTRL_REG3);
+    Wire.write(_ctrlReg3);
+    Wire.endTransmission();
+}
+
+void AxisHw::writeCtrlReg4(){
+    Wire.beginTransmission(_addr);
+    Wire.write(CTRL_REG4);
+    Wire.write(_ctrlReg4);
+    Wire.endTransmission();
+}
+
+void AxisHw::writeCtrlReg5(){
+    Wire.beginTransmission(_addr);
+    Wire.write(CTRL_REG5);
+    Wire.write(_ctrlReg5);
+    Wire.endTransmission();
+}

--- a/stmhw.h
+++ b/stmhw.h
@@ -1,0 +1,38 @@
+#ifndef HW_H
+#define HW_H
+
+#include <stdint.h>
+
+class AxisHw
+{
+private:
+    uint8_t _addr;
+
+public:
+    AxisHw (uint8_t addr) : _addr (addr) {}
+
+    uint8_t readByte(uint8_t reg);
+    int16_t readX();
+    int16_t readY();
+    int16_t readZ();
+
+    void readXYZ(int16_t *x, int16_t *y, int16_t *z);
+
+protected:
+    uint8_t _ctrlReg1;
+    uint8_t _ctrlReg2;
+    uint8_t _ctrlReg3;
+    uint8_t _ctrlReg4;
+    uint8_t _ctrlReg5;
+
+    float _mult;
+
+    void writeCtrlReg1();
+    void writeCtrlReg2();
+    void writeCtrlReg3();
+    void writeCtrlReg4();
+    void writeCtrlReg5();
+
+    int16_t readAxis(uint8_t reg);
+};
+#endif //HW_H

--- a/stmhw.h
+++ b/stmhw.h
@@ -8,6 +8,8 @@ class AxisHw
 private:
     uint8_t _addr;
 
+    static inline void waitForData();
+
 public:
     AxisHw (uint8_t addr) : _addr (addr) {}
 


### PR DESCRIPTION
There is a lot of identical code which can be hidden in the base class.
It can reduce copy-paste errors probability and also code size itself (just a little bit, but for no cost).

I'm going to do some more code clean-up, so this commit will help to reduce code changes in future.
