### PR TITLE
use constants from Arduino.h

### DIFF
--- a/MadgwickAHRS.cpp
+++ b/MadgwickAHRS.cpp
@@ -2,8 +2,6 @@
 #include <math.h>
 #include <Arduino.h>
 
-#define RAD_TO_DEG  57.2
-
 Madgwick::Madgwick() {
 
 }

--- a/l3g4200d.cpp
+++ b/l3g4200d.cpp
@@ -2,8 +2,6 @@
 #include <Wire.h>
 #include "l3g4200d.h"
 
-#define DEG_TO_RAD      0.0175
-
 #define CTRL_REG1       0x20
 #define CTRL_REG2       0x21
 #define CTRL_REG3       0x22

--- a/lis3mdl.cpp
+++ b/lis3mdl.cpp
@@ -154,12 +154,11 @@ float LIS3MDL_TWI::readAzimut() {
     float heading = atan2(_yCalibrate, _xCalibrate);
 
     if(heading < 0)
-    heading += 2 * PI;
+        heading += TWO_PI;
+    else if(heading > TWO_PI)
+        heading -= TWO_PI;
 
-    if(heading > 2 * PI)
-    heading -= 2 * PI;
-
-    float headingDegrees = heading * 180 / M_PI;
+    float headingDegrees = heading * RAD_TO_DEG;
 
     return headingDegrees;
 }


### PR DESCRIPTION
Since RAD_TO_DEG/DEG_TO_RAD and TWO_PI are defined in <Arduino.h> it would be better to use it from there.

At least it helps to avoid such warnings:

> Troyka-IMU/MadgwickAHRS.cpp:5:0: warning: "RAD_TO_DEG" redefined
> # define RAD_TO_DEG  57.2
> 
> In file included from arduino-1.6.10/libraries/Troyka-IMU/MadgwickAHRS.cpp:3:0:
> arduino-1.6.10/hardware/arduino/avr/cores/arduino/Arduino.h:51:0: note: this is the location of the >previous definition
> # define RAD_TO_DEG 57.295779513082320876798154814105
