### PR TITLE
Cleanup and small tweaks.

### DIFF
--- a/l3g4200d.cpp
+++ b/l3g4200d.cpp
@@ -75,29 +75,28 @@ float L3G4200D_TWI::readDegPerSecZ() {
 }
 
 float L3G4200D_TWI::readRadPerSecX() {
-    return readX() * _mult * DEG_TO_RAD;
+    return readDegPerSecX() * DEG_TO_RAD;
 }
 
 float L3G4200D_TWI::readRadPerSecY() {
-    return readY() * _mult * DEG_TO_RAD;
+    return readDegPerSecY() * DEG_TO_RAD;
 }
 
 float L3G4200D_TWI::readRadPerSecZ() {
-    return readZ() * _mult * DEG_TO_RAD;
+    return readDegPerSecZ() * DEG_TO_RAD;
 }
 
 void L3G4200D_TWI::readDegPerSecXYZ(float *gx, float *gy, float *gz) {
     int16_t x, y, z;
     readXYZ(&x, &y, &z);
-    *gx = (float)x * _mult;
-    *gy = (float)y * _mult;
-    *gz = (float)z * _mult;
+    *gx = x * _mult;
+    *gy = y * _mult;
+    *gz = z * _mult;
 }
 
 void L3G4200D_TWI::readRadPerSecXYZ(float *gx, float *gy, float *gz) {
-    int16_t x, y, z;
-    readXYZ(&x, &y, &z);
-    *gx = (float)x * _mult * DEG_TO_RAD;
-    *gy = (float)y * _mult * DEG_TO_RAD;
-    *gz = (float)z * _mult * DEG_TO_RAD;
+    readDegPerSecXYZ(gx, gy, gz);
+    (*gx) *= DEG_TO_RAD;
+    (*gy) *= DEG_TO_RAD;
+    (*gz) *= DEG_TO_RAD;
 }

--- a/lis331dlh.cpp
+++ b/lis331dlh.cpp
@@ -71,29 +71,28 @@ float LIS331DLH_TWI::readGZ() {
 }
 
 float LIS331DLH_TWI::readAX() {
-    return readX()*_mult * G;
+    return readGX() * G;
 }
 
 float LIS331DLH_TWI::readAY() {
-    return readY() * _mult * G;
+    return readGY() * G;
 }
 
 float LIS331DLH_TWI::readAZ() {
-    return readZ() * _mult * G;
+    return readGZ() * G;
 }
 
 void LIS331DLH_TWI::readGXYZ(float *gx, float *gy, float *gz) {
     int16_t x, y, z;
     readXYZ(&x, &y, &z);
-    *gx = (float)x * _mult;
-    *gy = (float)y * _mult;
-    *gz = (float)z * _mult;
+    *gx = x * _mult;
+    *gy = y * _mult;
+    *gz = z * _mult;
 }
 
 void LIS331DLH_TWI::readAXYZ(float *ax, float *ay, float *az) {
-    int16_t x, y, z;
-    readXYZ(&x, &y, &z);
-    *ax = (float)x * _mult * G;
-    *ay = (float)y * _mult * G;
-    *az = (float)z * _mult * G;
+    readGXYZ(ax, ay, az);
+    (*ax) *= G;
+    (*ay) *= G;
+    (*az) *= G;
 }

--- a/lis3mdl.cpp
+++ b/lis3mdl.cpp
@@ -110,13 +110,8 @@ void LIS3MDL_TWI::calibrate() {
 }
 
 void LIS3MDL_TWI::calibrateMatrix(const double calibrationMatrix[3][3], const double bias[3]) {
-    for(int i = 0; i < 3; i++)
-        _bias[i] = bias[i];
-
-    for (int i = 0; i < 3; i++) {
-        for (int j = 0; j < 3; j++)
-        _calibrationMatrix[i][j] = calibrationMatrix[i][j];
-    }  
+    memcpy (_bias, bias, 3 * sizeof (double));
+    memcpy (_calibrationMatrix, calibrationMatrix, 3 * 3 * sizeof (double));
 }
 
 void LIS3MDL_TWI::readCalibrateGaussXYZ(float *x, float *y, float *z) {

--- a/lis3mdl.cpp
+++ b/lis3mdl.cpp
@@ -52,6 +52,15 @@ void LIS3MDL_TWI::setRange(uint8_t range) {
     writeCtrlReg2();
 }
 
+void LIS3MDL_TWI::sleep(bool enable) {
+    if (enable)
+        _ctrlReg3 |= (3 << 0);
+    else
+        _ctrlReg3 &= ~(3 << 0);
+
+    writeCtrlReg3();
+}
+
 float LIS3MDL_TWI::readGaussX() {
     return readX() / _mult;
 }

--- a/lis3mdl.h
+++ b/lis3mdl.h
@@ -15,6 +15,7 @@ class LIS3MDL_TWI : public AxisHw
 public:
     LIS3MDL_TWI(uint8_t addr = LIS3MDL_TWI_ADDRESS);
     void begin();
+    void sleep(bool enable);
     void setRange(uint8_t range);
     void calibrateMatrix(const double calibrationMatrix[3][3], const double bias[3]);
     void calibrate();


### PR DESCRIPTION
This pull request contains 4 various cleanup patches.
- The first one is just `for-loop` to `memcpy` replacement. Disassembler and various measurements show some code size reduction and most probably library call is more optimized.
- The second one replaces similar functions with sequential function call, because the second function is just unit transformation routine and completely depends on results of the first function. It reduces copy-paste errors and helps to avoid missed scaling or other kind of initial raw value transformations.
- The third one just adds 'sleep' function for magnetometer to provide similar functionality as the other STM devices. I'm thinking how to move this function to the base class.
- The last one replaces numeric constants with named ones. Actually it would be better to define such constants for all the registers, but it can be a big change and most probably I'll do that in separate pull request.

Hope this is useful.
