### PR TITLE
deal with strict aliasing warnings

### DIFF
--- a/MadgwickAHRS.cpp
+++ b/MadgwickAHRS.cpp
@@ -204,10 +204,13 @@ void Madgwick::update(float gx, float gy, float gz, float ax, float ay, float az
 
 float Madgwick::invSqrt(float x) {
 	float halfx = 0.5f * x;
-	float y = x;
-	long i = *(long*)&y;
+	union {
+	    float y;
+	    long i;
+	};
+	static_assert (sizeof(float) == sizeof(long), "sizeof(float) must be equal sizeof(long) to apply this optimization");
+	y = x;
 	i = 0x5f3759df - (i >> 1);
-	y = *(float*)&i;
 	y = y * (1.5f - (halfx * y * y));
 	return y;
 }


### PR DESCRIPTION
This commit fixes "warning: dereferencing type-punned pointer will break strict-aliasing rules" warning and adds some additional compile-time checks.
