### PR TITLE
Barometer v1 initialization fix

### DIFF
--- a/src/Barometer.cpp
+++ b/src/Barometer.cpp
@@ -10,7 +10,7 @@ void Barometer::begin(TwoWire& wire) {
     _deviceID = readDeviceID();
     uint8_t data = 0;
     if (_deviceID == LPS331_WHO_AM_I) {
-        data |= LPS_CTRL_REG1_ODR0 | LPS_CTRL_REG1_ODR1 | LPS_CTRL_REG1_ODR2;
+        data |= LPS_CTRL_REG1_ODR1 | LPS_CTRL_REG1_ODR2;
     } else if (_deviceID == LPS25HB_WHO_AM_I) {
         data |= LPS_CTRL_REG1_ODR2;
     }


### PR DESCRIPTION
Use 12.5Hz/12.5Hz, cause register configuration 7Ah (default) not allowed with ODR = 25Hz/25Hz (Register CTRL_REG1). For ORD
25Hz/25Hz the suggested configuration for RES_CONF is 6Ah.